### PR TITLE
Test TOC update to fix hyperlink issue

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -6,11 +6,11 @@ parts:
       - file: pf7/Data_access.ipynb
       - file: pf7/examples.md
         sections:
-        - file: pf7/analysis_examples/chloroquine-resistance-map.ipynb
-        - file: pf7/analysis_examples/sample-summary-table.ipynb
-        - file: pf7/analysis_examples/variant-summary-table.ipynb
-        - file: pf7/analysis_examples/neighbour-joining-tree-swga.ipynb
-        - file: pf7/analysis_examples/proportion-eba175.ipynb
+        - file: pf7/analysis_examples/chloroquine-resistance-map
+        - file: pf7/analysis_examples/sample-summary-table
+        - file: pf7/analysis_examples/variant-summary-table
+        - file: pf7/analysis_examples/neighbour-joining-tree-swga
+        - file: pf7/analysis_examples/proportion-eba175
       - file: pf7/api
   - caption: Pv4
     chapters:


### PR DESCRIPTION
Currently all .ipynb headers are appearing as hyperlinks on the Analysis Examples page. 

Using Vector's TOC as an example, does removing the .ipynb extension from the `_toc.yml` fix this issue?