### PR TITLE
Update gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,11 +11,11 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 


### PR DESCRIPTION
actions running on node 16 deprecated, deployment failed as a result. Updating to latest versions (v4) which run on new node 20.

```
[deploy-docs](https://github.com/malariagen/parasite-data/actions/runs/7842462576/job/21400844052)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v1.
```