### PR TITLE
Add cloud data access info

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,6 +1,9 @@
 format: jb-book
 root: landing-page
 parts:
+  - caption: Malaria Parasite Data Access
+    chapters:
+      - file: cloud_data_access/parasite-cloud-data-access.ipynb
   - caption: Pf7
     chapters:
       - file: pf7/Data_access.ipynb

--- a/docs/cloud_data_access/parasite-cloud-data-access.ipynb
+++ b/docs/cloud_data_access/parasite-cloud-data-access.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "038d7e27-4cd4-45bc-bb2c-f73b9993e444",
+   "metadata": {},
+   "source": [
+    "# **Malaria Parasite Data Access**\n",
+    "\n",
+    "MalariaGEN data resources provide an integrated view of malaria parasite genomes from across the globe. These data are available to everyone to benefit the science and surveillance of malaria. You can find more information on the parasite data resources [here](https://www.malariagen.net/parasite/).\n",
+    "\n",
+    "MalariaGEN parasite data are stored in Google Cloud Storage (GCS). The current set-up requires users to request access and authenticate prior to accessing data. \n",
+    "\n",
+    "---\n",
+    "\n",
+    "To access MalariaGEN parasite data, you will need to follow these steps:\n",
+    "\n",
+    "#### Step 1. Make sure you have a Google Account\n",
+    "\n",
+    "To allow us to configure data access permissions, you will need to provide us with an email address that is associated with a Google account. This could be a standard Google (i.e., GMail) account, or alternatively it could be your work email if your employer uses Google Workspace.\n",
+    "\n",
+    "#### Step 2. Fill out the data access request form\n",
+    "\n",
+    "Please fill out and submit the following form:\n",
+    "\n",
+    "> [MalariaGEN cloud data access form](https://forms.gle/kCqistorZyxaU4LP7)\n",
+    "\n",
+    "All requests for data access will be granted, subject to verification checks and agreement to reasonable use. This is to ensure that the data resources remain accessible to everyone. Submitting this form will allow us to configure storage permissions and monitor storage for excessive network usage in future.\n",
+    "\n",
+    "#### Step 3. Ensure you are using the latest version of the `malariagen_data` Python package\n",
+    "\n",
+    "If you access data via the `malariagen_data` Python package, please upgrade to version 9.0 or higher. These versions will automatically use your authentication credentials when accessing data in Google Cloud.\n",
+    "\n",
+    "#### Step 4. Set up Google Cloud authentication credentials\n",
+    "\n",
+    "If you are only accessing data via the `malariagen_data` Python package from within Google Colab, you can skip this step, because authentication credentials will be obtained automatically.\n",
+    "\n",
+    "If you are accessing data from any other location, you will need to authenticate with Google Cloud. To do this, you will need to:\n",
+    "\n",
+    "1. Install the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud). See the details in the Google Documentation [here](https://cloud.google.com/sdk/docs/install-sdk).\n",
+    "\n",
+    "\n",
+    "2. Check `gcloud` is installed correctly:\n",
+    "\n",
+    "```bash\n",
+    "gcloud help\n",
+    "```\n",
+    "\n",
+    "3. Authenticate using `gcloud`: \n",
+    "\n",
+    "- If you need to authenticate within the `malariagen_data` package, you will need to use the following command:\n",
+    "\n",
+    "```bash\n",
+    "gcloud auth application-default login\n",
+    "```\n",
+    "\n",
+    "- If you need to authenticate to access Google Cloud Storage from the command line using `gsutil`, you will need to use the following command:\n",
+    "\n",
+    "```bash\n",
+    "gcloud auth login\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed024cac-be61-44a0-a339-821a9f70a456",
+   "metadata": {},
+   "source": [
+    "If you have any questions, please contact us at: <support@malariagen.net>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Since updating user authentication requirements for Google Cloud storage, we need to provide info on how to set this up. 

I have copied across the user guide from vector, and amended to make parasite-specific. 

