### PR TITLE
udpate malariagen_data version dependency

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,4 +1,4 @@
 jupyter-book==0.11.3
-malariagen_data==7.0.0
+malariagen_data==15.0.0
 Jinja2<3.1
 numpydoc>=1.4.0


### PR DESCRIPTION
Currently the Pf8 API page doesn't load, as the `requirements_deploy.txt` doc loads `malariagen_data` v7.0.0, pre-Pf8 release. 

This updates to v15.0.0 where [Pf8 functionality was released](https://github.com/malariagen/malariagen-data-python/releases?page=1). 