### PR TITLE
Fix snp only zarr url

### DIFF
--- a/docs/pf8/Data_access.ipynb
+++ b/docs/pf8/Data_access.ipynb
@@ -3624,7 +3624,7 @@
       ],
       "source": [
         "# Access the SNP-only callset\n",
-        "pf8_snp_only  = malariagen_data.Pf8('s3://pf8-release/snp-only/')\n",
+        "pf8_snp_only  = malariagen_data.Pf8('https://pf8-release.cog.sanger.ac.uk/snp-only')\n",
         "variant_dataset_snp_only = pf8_snp_only.variant_calls()\n",
         "variant_dataset_snp_only"
       ]

--- a/docs/pf8/summarise_data/table_variants_summary.ipynb
+++ b/docs/pf8/summarise_data/table_variants_summary.ipynb
@@ -1940,7 +1940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -3233,7 +3233,7 @@
     }
    ],
    "source": [
-    "release_data = malariagen_data.Pf8('s3://pf8-release/snp-only/')\n",
+    "release_data = malariagen_data.Pf8('https://pf8-release.cog.sanger.ac.uk/snp-only')\n",
     "variant_data = release_data.variant_calls()\n",
     "variant_data"
    ]


### PR DESCRIPTION
User highlighted that the URL `s3://pf8-release/snp-only/` was not working, returning an error when trying to load the Pf8 snp-only callset in two notebooks: Pf8 data access and the table of variants summary notebook.

The fix is to change URL to `https://pf8-release.cog.sanger.ac.uk/snp-only` in both notebooks. 