### PR TITLE
Updating requirements versions

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,4 +1,4 @@
-jupyter-book==0.11.3
-malariagen_data==8.8.0
-Jinja2<3.1
+jupyter-book==0.15.1
+malariagen_data==15.8.0
+Jinja2>=3.1.3
 numpydoc>=1.4.0


### PR DESCRIPTION
Issues identified: #83 #59 

- Requires updating malariagen_data version from current `7.0.0` which does not contain Pf8 functionality to `15.8.0` which does
- Also upgrading Jinja2 from `<3.1` to `~> 3.1.3`
- Test deployment on local machine also requires upgrading Jupyter book version to handle these changes. Version changed from `0.11.3` to `0.15.1`

Changes tested in dev environment and resolved Pf8 API rendering issues. 